### PR TITLE
Fix typo in luasnip.lua

### DIFF
--- a/nvim/lua/plugins/luasnip.lua
+++ b/nvim/lua/plugins/luasnip.lua
@@ -1,6 +1,6 @@
 return {
 	"L3MON4D3/LuaSnip",
-	dependecies = {
+	dependencies = {
 		"saadparwaiz1/cmp_luasnip",
 		"rafamadriz/friendly-snippets",
 	},


### PR DESCRIPTION
There's a typo in luasnip.lua that prevents dependencies from loading